### PR TITLE
NSInvalidArgumentException in ELCAlbumPickerController.m

### DIFF
--- a/Classes/ELCImagePicker/ELCAlbumPickerController.m
+++ b/Classes/ELCImagePicker/ELCAlbumPickerController.m
@@ -122,7 +122,8 @@ static CGSize const kAlbumThumbnailSize1 = {70.0f , 70.0f};
     options.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:NO]];
     PHFetchResult *assetsFetchResult = [PHAsset fetchAssetsWithOptions:options];
     
-    [self.assetGroups addObject:@{@"All Photos":assetsFetchResult}];
+    if (assetsFetchResult != nil)
+        [self.assetGroups addObject:@{@"All Photos":assetsFetchResult}];
     
     
     PHFetchResult *topLevelUserCollections = [PHCollectionList fetchTopLevelUserCollectionsWithOptions:nil];


### PR DESCRIPTION
I get quite a lot of crashes like this:

```
ELCAlbumPickerController.m line 125
-[ELCAlbumPickerController updateFetchResults]

Fatal Exception: NSInvalidArgumentException
*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[0]
```

Should probably be enough to check if assetsFetchResult is not nil to fix this.
